### PR TITLE
Renamed the package to avoid npm dependency collisions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "materialize-css",
+  "name": "g5-materialize-css",
   "description": "Builds Materialize distribution packages",
   "author": "Alvin Wang, Alan Chang",
   "url": "http://materializecss.com/",


### PR DESCRIPTION
@lance-hardy on the dashboard we were having issues where this package wasn't installing at all because of the name collision with the actual `materialize-css` npm package.  So I added the g5 namespace to avoid that problem.  
