### PR TITLE
layout modal tweak

### DIFF
--- a/sass/components/g5/forms/_select.scss
+++ b/sass/components/g5/forms/_select.scss
@@ -34,17 +34,6 @@ $chevron-down: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAMCAYAAABvEu
 }
 
 .modal  {
-  .select-row-layout {
-    .select-wrapper {
-      margin-left: 10px;
-      max-width: 47%;
-    }
-  }
-
-  .note {
-    margin-left: 10px;
-  }
-
   .form-field.draggable-widget {
     margin-left: 0;
 


### PR DESCRIPTION
- Removes modal stylings invoked by `edit-layout.scss` -- these are specific to layout widget editing and has nothing to do with generic modals
