### PR TITLE
Fixes Version Header

### DIFF
--- a/sass/components/g5/_navbar.scss
+++ b/sass/components/g5/_navbar.scss
@@ -7,7 +7,6 @@
   }
 
   .version {
-    float: right;
-    padding-right: calc(100% - 94%);
+    padding: 0 15px;
   }
 }


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* Fixes Version Header to stop wrap overlap over next important element.
* 

### Important Links (Pivotal, Additional Repositories, etc):
- https://www.pivotaltracker.com/story/show/149935902
- https://github.com/g5search/orion-cms/pull/382
- https://github.com/g5search/g5-content-management-system/pull/2893

### Additional Information (Optional)
Why must we calculate what 100%-94% is?!
SPOILER: 6%
I'm setting the padding to match the breadcrumb spacing in this header.
I'm also using the `right` class from materialize on the element for the right float.
I imagine we were getting partial pixels while doing the percentage / calculation.
